### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/components/providers/ThemeProvider.tsx
+++ b/src/app/components/providers/ThemeProvider.tsx
@@ -57,6 +57,20 @@ const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     }
   }, []);
 
+  // Utility function to escape HTML special characters
+  const escapeHTML = (str: string): string => {
+    return str.replace(/[&<>"']/g, (match) => {
+      const escapeMap: { [key: string]: string } = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      };
+      return escapeMap[match];
+    });
+  };
+
   // Function to apply theme-specific transformations
   const applyThemeTransformations = (currentTheme: string) => {
     if (typeof window === "undefined") return;
@@ -68,7 +82,7 @@ const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     headings.forEach((heading) => {
       heading.classList.remove("theme-box");
       // Restore original content without special formatting
-      heading.innerHTML = heading.textContent || "";
+      heading.innerHTML = escapeHTML(heading.textContent || "");
     });
 
     textElements.forEach((el) => {


### PR DESCRIPTION
Potential fix for [https://github.com/craighagemeier/craig-hagemeier-site/security/code-scanning/1](https://github.com/craighagemeier/craig-hagemeier-site/security/code-scanning/1)

To fix the problem, we need to ensure that any text content assigned to `innerHTML` is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using a utility function to escape HTML special characters before assigning the text to `innerHTML`.

- We will create a utility function `escapeHTML` that replaces HTML special characters with their corresponding HTML entities.
- We will use this function to escape the text content before assigning it to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
