### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/app/components/providers/ThemeProvider.tsx
+++ b/src/app/components/providers/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useState, useEffect } from "react";
+
 import { usePathname } from "next/navigation";
 
 interface ThemeContextType {
@@ -81,7 +82,7 @@ const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) =>
     // Apply transformations for monochrome theme (first letter effect for all headings)
     if (currentTheme === "monochrome") {
       headings.forEach((heading) => {
-        heading.innerHTML = heading.textContent?.replace(/\b(\w)/g, "<span class='theme-first-letter'>$1</span>") || "";
+        heading.innerHTML = escapeHtml(heading.textContent)?.replace(/\b(\w)/g, "<span class='theme-first-letter'>$1</span>") || "";
       });
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/craighagemeier/craig-hagemeier-site/security/code-scanning/2](https://github.com/craighagemeier/craig-hagemeier-site/security/code-scanning/2)

To fix the problem, we need to ensure that any text content extracted from the DOM is properly escaped before being reinserted as HTML. This can be achieved by creating a utility function that escapes HTML special characters. We will then use this function to escape the text content before applying the transformations.

1. Create a utility function to escape HTML special characters.
2. Use this function to escape `heading.textContent` before setting it as `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
